### PR TITLE
Change Demo Researcher login button color to match the rest of the application

### DIFF
--- a/project/src/components/auth/login-buttons.tsx
+++ b/project/src/components/auth/login-buttons.tsx
@@ -50,7 +50,7 @@ export default function LoginButtons() {
         <button
           onClick={() => handleDemoLogin("researcher")}
           disabled={isLoading}
-          className={`px-4 py-2 text-sm font-medium text-white bg-secondary rounded-md hover:bg-secondary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-secondary ${
+          className={`px-4 py-2 text-sm font-medium text-white bg-primary rounded-md hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary ${
             isLoading && selectedDemo === "researcher" ? "opacity-75 cursor-not-allowed" : ""
           }`}
         >


### PR DESCRIPTION
## Summary
- Changed Demo Researcher login button color from yellow (bg-secondary) to blue (bg-primary) to match the application's color scheme
- Updated focus ring to match the new button color

Fixes #17

## Test plan
- Run the application and verify the Demo Researcher login button appears blue instead of yellow
- Check that hover and focus states use the correct blue shades

🤖 Generated with [Claude Code](https://claude.ai/code)