### PR TITLE
Disable React strict mode

### DIFF
--- a/project/next.config.js
+++ b/project/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   images: {
     domains: ['lh3.googleusercontent.com', 'graph.microsoft.com', 'ui-avatars.com'],
   },


### PR DESCRIPTION
## Summary
- Disabled React strict mode to prevent duplicate renders and improve development experience

## Test plan
- Verify application functions correctly without strict mode enabled
- Check console for any strict-mode related warnings that may have been suppressed

🤖 Generated with [Claude Code](https://claude.ai/code)