### PR TITLE
Add theme toggle feature with dark mode support

### DIFF
--- a/project/src/app/globals.css
+++ b/project/src/app/globals.css
@@ -2,6 +2,44 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    --background: 255 255 255;
+    --foreground: 15 23 42;
+    --card: 255 255 255;
+    --card-foreground: 15 23 42;
+    --popover: 255 255 255;
+    --popover-foreground: 15 23 42;
+    --primary: 20 184 166;
+    --primary-foreground: 255 255 255;
+    --secondary: 233 196 106;
+    --secondary-foreground: 0 0 0;
+    --accent: 231 111 81;
+    --accent-foreground: 255 255 255;
+    --border: 226 232 240;
+    --input: 226 232 240;
+    --ring: 20 184 166;
+  }
+
+  .dark {
+    --background: 15 23 42;
+    --foreground: 241 245 249;
+    --card: 30 41 59;
+    --card-foreground: 241 245 249;
+    --popover: 30 41 59;
+    --popover-foreground: 241 245 249;
+    --primary: 20 184 166;
+    --primary-foreground: 255 255 255;
+    --secondary: 233 196 106;
+    --secondary-foreground: 0 0 0;
+    --accent: 231 111 81;
+    --accent-foreground: 255 255 255;
+    --border: 51 65 85;
+    --input: 51 65 85;
+    --ring: 20 184 166;
+  }
+}
+
 /* Custom scrollbar styles */
 ::-webkit-scrollbar {
   width: 6px;
@@ -34,18 +72,18 @@
   }
   
   .btn-secondary {
-    @apply px-4 py-2 bg-secondary text-gray-800 rounded-md hover:bg-secondary-dark focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-opacity-50 transition duration-150 ease-in-out;
+    @apply px-4 py-2 bg-secondary text-gray-800 dark:text-gray-100 rounded-md hover:bg-secondary-dark focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-opacity-50 transition duration-150 ease-in-out;
   }
   
   .btn-outline {
-    @apply px-4 py-2 border border-dark-green-500 text-dark-green-500 rounded-md hover:bg-dark-green-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-dark-green-400 focus:ring-opacity-50 transition duration-150 ease-in-out;
+    @apply px-4 py-2 border border-dark-green-500 text-dark-green-500 dark:text-dark-green-300 rounded-md hover:bg-dark-green-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-dark-green-400 focus:ring-opacity-50 transition duration-150 ease-in-out;
   }
   
   .input-field {
-    @apply px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dark-green-400 focus:border-dark-green-500;
+    @apply px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-dark-green-400 focus:border-dark-green-500;
   }
   
   .card {
-    @apply bg-white rounded-lg shadow-md p-6;
+    @apply bg-white dark:bg-gray-800 dark:text-gray-100 rounded-lg shadow-md p-6;
   }
 }

--- a/project/src/app/layout.tsx
+++ b/project/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import AuthProvider from "@/lib/auth-provider";
 import ToastProvider from "@/components/toast-provider";
+import { ThemeProvider } from "@/lib/theme-context";
 
 // Configure Inter font with fallbacks and preloading disabled
 const inter = Inter({ 
@@ -37,9 +38,11 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <AuthProvider>
-          <ToastProvider>
-            {children}
-          </ToastProvider>
+          <ThemeProvider>
+            <ToastProvider>
+              {children}
+            </ToastProvider>
+          </ThemeProvider>
         </AuthProvider>
       </body>
     </html>

--- a/project/src/components/layout/authenticated-layout.tsx
+++ b/project/src/components/layout/authenticated-layout.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { signOut, useSession } from "next-auth/react";
 import Image from "next/image";
+import ThemeToggle from "@/components/theme-toggle";
 
 interface SidebarLink {
   href: string;
@@ -130,7 +131,7 @@ export default function AuthenticatedLayout({
   };
 
   return (
-    <div className="h-screen flex overflow-hidden bg-light-green">
+    <div className="h-screen flex overflow-hidden bg-light-green dark:bg-gray-900">
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
@@ -246,15 +247,18 @@ export default function AuthenticatedLayout({
       <div className="hidden md:flex md:flex-shrink-0">
         <div className="flex flex-col w-64">
           <div className="flex flex-col h-0 flex-1">
-            <div className="flex items-center h-16 flex-shrink-0 px-4 bg-primary">
-              <div className="h-8 w-8 flex items-center justify-center">
-                <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M20 50 L40 70 L80 30" stroke="white" strokeWidth="10" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                  <circle cx="20" cy="30" r="8" fill="white" />
-                  <circle cx="80" cy="70" r="8" fill="white" />
-                </svg>
+            <div className="flex items-center justify-between h-16 flex-shrink-0 px-4 bg-primary">
+              <div className="flex items-center">
+                <div className="h-8 w-8 flex items-center justify-center">
+                  <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M20 50 L40 70 L80 30" stroke="white" strokeWidth="10" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                    <circle cx="20" cy="30" r="8" fill="white" />
+                    <circle cx="80" cy="70" r="8" fill="white" />
+                  </svg>
+                </div>
+                <span className="ml-2 text-xl font-bold text-white">AgTrial</span>
               </div>
-              <span className="ml-2 text-xl font-bold text-white">AgTrial</span>
+              <ThemeToggle />
             </div>
             <div className="flex-1 flex flex-col overflow-y-auto bg-primary">
               <nav className="flex-1 px-2 py-4 space-y-1">
@@ -314,7 +318,7 @@ export default function AuthenticatedLayout({
 
       {/* Main content */}
       <div className="flex flex-col w-0 flex-1 overflow-hidden">
-        <div className="relative z-10 flex-shrink-0 flex h-16 bg-white shadow md:hidden">
+        <div className="relative z-10 flex-shrink-0 flex h-16 bg-white dark:bg-gray-800 shadow md:hidden">
           <button
             type="button"
             className="px-4 border-r border-gray-200 text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary md:hidden"
@@ -340,7 +344,7 @@ export default function AuthenticatedLayout({
           <div className="flex-1 px-4 flex justify-between">
             <div className="flex-1 flex">
               <div className="w-full flex items-center">
-                <div className="text-xl font-semibold text-gray-900">
+                <div className="text-xl font-semibold text-gray-900 dark:text-gray-100">
                   {pathname === "/dashboard"
                     ? "Dashboard"
                     : pathname.split("/").pop() 
@@ -349,6 +353,9 @@ export default function AuthenticatedLayout({
                       : "Page"}
                 </div>
               </div>
+            </div>
+            <div className="ml-4 flex items-center md:ml-6">
+              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/project/src/components/theme-toggle.tsx
+++ b/project/src/components/theme-toggle.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useTheme } from '@/lib/theme-context';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? (
+        // Moon icon for dark mode
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+        </svg>
+      ) : (
+        // Sun icon for light mode
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/project/src/lib/theme-context.tsx
+++ b/project/src/lib/theme-context.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  // Use client-side storage with fallback to default theme
+  const [theme, setTheme] = useState<Theme>('light');
+  
+  // Initialize theme from localStorage on client side
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme') as Theme;
+    if (storedTheme) {
+      setTheme(storedTheme);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  // Update the data-theme attribute and localStorage when theme changes
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => prevTheme === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/project/tailwind.config.js
+++ b/project/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- Added theme toggle component and theme context provider to enable switching between light and dark modes
- Implemented dark mode CSS variables and added Tailwind configuration for dark mode support
- Theme preferences are saved to localStorage for persistence between sessions
- Added UI components to toggle between themes in both mobile and desktop layouts

## Test plan
- Verify the theme toggle appears in the navigation UI
- Test switching between light and dark modes
- Confirm theme preference is saved when reloading the page
- Check that all UI components render correctly in both light and dark modes
- Test responsiveness of theme toggle in mobile and desktop layouts

🤖 Generated with [Claude Code](https://claude.ai/code)